### PR TITLE
Only show the admin bar menu if the user can view logs

### DIFF
--- a/classes/class-network.php
+++ b/classes/class-network.php
@@ -135,6 +135,10 @@ class Network {
 			return;
 		}
 
+		if ( ! current_user_can( $this->plugin->admin->view_cap ) ) {
+			return;
+		}
+
 		$href = add_query_arg(
 			array(
 				'page' => $this->plugin->admin->records_page_slug,


### PR DESCRIPTION
It's possible for a user on a Multisite network to have access to the Network Admin screens without being a Super Admin, for example via a role which grants the `manage_network` capability.

In this situation, the 'Stream' menu shows up in the admin toolbar menu even though the user doesn't have access to it. If they click the menu item they'll see a "Sorry, you are not allowed to access this page" error message.

This fixes that.

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [ ] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- Fix: Describe a bug fix included in this release.
